### PR TITLE
Make OpenSSLDRBG thread-safe

### DIFF
--- a/src/main/java/com/canonical/openssl/cipher/OpenSSLCipher.java
+++ b/src/main/java/com/canonical/openssl/cipher/OpenSSLCipher.java
@@ -30,6 +30,12 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.BadPaddingException;
 
+/* This implementation will be exercised by the user through the
+ * javax.crypto.Cipher API which isn't marked thread-safe.
+ * This implementation is also NOT thread-safe and applications need
+ * handle thread-safety concerns if need be.
+ */
+
 abstract public class OpenSSLCipher extends CipherSpi {
 
     static {

--- a/src/main/java/com/canonical/openssl/kdf/OpenSSLPBKDF2.java
+++ b/src/main/java/com/canonical/openssl/kdf/OpenSSLPBKDF2.java
@@ -41,6 +41,12 @@ import javax.crypto.SecretKeyFactorySpi;
  * can be represented by class PBEKeySpec. As a result, only PBKDF2
  * is implemented in this prototype.
  */
+
+/* This implementation will be exercised by the user through the
+ * javax.crypto.SecretKeyFactory API which isn't marked thread-safe.
+ * This implementation is also NOT thread-safe and applications need
+ * handle any concerns regarding the same.
+ */
 public class OpenSSLPBKDF2 extends SecretKeyFactorySpi {
 
     static {

--- a/src/main/java/com/canonical/openssl/keyagreement/OpenSSLKeyAgreement.java
+++ b/src/main/java/com/canonical/openssl/keyagreement/OpenSSLKeyAgreement.java
@@ -26,6 +26,12 @@ import javax.crypto.KeyAgreementSpi;
 import javax.crypto.SecretKey;
 import java.util.Base64;
 
+/* This implementation will be exercised by the user through the
+ * javax.crypto.KeyAgreement API which isn't marked thread-safe.
+ * This implementation is also NOT thread-safe and applications need
+ * handle thread-safety concerns if need be.
+ */
+
 abstract public class OpenSSLKeyAgreement extends KeyAgreementSpi {
     static {
         NativeLibraryLoader.load();

--- a/src/main/java/com/canonical/openssl/keyencapsulation/OpenSSLKEMRSA.java
+++ b/src/main/java/com/canonical/openssl/keyencapsulation/OpenSSLKEMRSA.java
@@ -36,6 +36,12 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import javax.crypto.spec.SecretKeySpec;
 
+/* This implementation will be exercised by the user through the
+ * javax.crypto.KEM API which isn't marked thread-safe.
+ * This implementation is also NOT thread-safe and applications need
+ * handle thread-safety concerns if need be.
+ */
+
 final public class OpenSSLKEMRSA implements KEMSpi {
 
     static {

--- a/src/main/java/com/canonical/openssl/mac/OpenSSLMAC.java
+++ b/src/main/java/com/canonical/openssl/mac/OpenSSLMAC.java
@@ -26,6 +26,12 @@ import javax.crypto.MacSpi;
 import java.security.spec.AlgorithmParameterSpec;
 import javax.xml.crypto.dsig.spec.HMACParameterSpec;
 
+/* This implementation will be exercised by the user through the
+ * javax.crypto.Mac API which isn't marked thread-safe.
+ * This implementation is also NOT thread-safe and applications need
+ * handle thread-safety concerns if need be.
+ */
+
 public abstract class OpenSSLMAC extends MacSpi {
 
     static {

--- a/src/main/java/com/canonical/openssl/md/OpenSSLMD.java
+++ b/src/main/java/com/canonical/openssl/md/OpenSSLMD.java
@@ -27,6 +27,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Set;
 
+/* This implementation will be exercised by the user through the
+ * java.security.MessageDigest API which isn't marked thread-safe.
+ * This implementation is also NOT thread-safe and applications need
+ * handle thread-safety concerns if need be.
+ */
 public abstract class OpenSSLMD extends MessageDigestSpi {
 
     static {

--- a/src/main/java/com/canonical/openssl/signature/OpenSSLSignature.java
+++ b/src/main/java/com/canonical/openssl/signature/OpenSSLSignature.java
@@ -31,6 +31,11 @@ import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
 
+/* This implementation will be exercised by the user through the
+ * java.security.Signature API which isn't marked thread-safe.
+ * This implementation is also NOT thread-safe and applications need
+ * handle thread-safety concerns if need be.
+ */
 public abstract class OpenSSLSignature extends SignatureSpi {
 
     static {


### PR DESCRIPTION
Make OpenSSLDRBG thread-safe through synchronization. Add comments making the absence of thread-safety clear for the rest of the implementation classes.