### PR TITLE
Adapt for Ubuntu Pro 22.04

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,19 +29,21 @@ jobs:
     - name: Install OpenSSL FIPS
       run: |
         git clone https://github.com/openssl/openssl && cd openssl
-        git checkout openssl-3.0
+        git checkout openssl-3.0.2
         sudo apt update && sudo apt install build-essential -y
         ./Configure enable-fips && make && sudo make install && sudo make install_fips
     - name: Setup OpenSSL configuration
       run: |
         sudo mkdir -p /usr/local/ssl
+        sudo openssl fipsinstall -out /usr/local/ssl/fipsmodule.cnf -module /usr/local/lib64/ossl-modules/fips.so
+        sudo cat /usr/local/ssl/fipsmodule.cnf
         sudo cp ${{ github.workspace }}/src/test/conf/openssl.cnf /usr/local/ssl/openssl.cnf
     - name: Build with Maven
       env:
         JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64/
       run: mvn -B package --file pom.xml
     - name: Upload logfile
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: maven-surefire-reports

--- a/src/main/java/com/canonical/openssl/provider/OpenSSLFIPSProvider.java
+++ b/src/main/java/com/canonical/openssl/provider/OpenSSLFIPSProvider.java
@@ -57,8 +57,10 @@ public final class OpenSSLFIPSProvider extends Provider {
 
         // Signatures
         put("Signature.RSA", "com.canonical.openssl.signature.SignatureRSA");
-        put("Signature.ED448", "com.canonical.openssl.signature.SignatureED448");
-        put("Signature.ED25519", "com.canonical.openssl.signature.SignatureED25519");
+        // The openssl FIPS provider for Ubuntu Pro does not have support for ED448 and ED25519.
+        // There is lack of clarity over the FIPS approval status of these algorithms.
+        // put("Signature.ED448", "com.canonical.openssl.signature.SignatureED448");
+        // put("Signature.ED25519", "com.canonical.openssl.signature.SignatureED25519");
 
         // Secret Key Factory
         put("SecretKeyFactory.PBKDF2", "com.canonical.openssl.kdf.PBKDF2withSHA512");

--- a/src/main/native/c/init.c
+++ b/src/main/native/c/init.c
@@ -34,6 +34,14 @@ OSSL_LIB_CTX *global_libctx = NULL;
 
 OSSL_LIB_CTX* load_openssl_provider(const char *name, const char* conf_file_path) {
     OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+
+    if (OSSL_PROVIDER_available(libctx, "fips")) {
+        // The FIPS module has been loaded by default.
+        // The base module should also be loaded and the default model not loaded.
+        // There's nothing more to do. This is the Ubuntu Pro setup.
+        return libctx;
+    }
+
     if (!OSSL_LIB_CTX_load_config(libctx, conf_file_path)) {
         ERR_print_errors_fp(stderr);
     }
@@ -43,7 +51,7 @@ OSSL_LIB_CTX* load_openssl_provider(const char *name, const char* conf_file_path
         fprintf(stderr, "Failed to load the %s provider:\n", name);
         ERR_print_errors_fp(stderr);
     }
-    
+
     return libctx;
 }
 

--- a/src/main/native/c/mac.c
+++ b/src/main/native/c/mac.c
@@ -44,7 +44,7 @@ static void set_params(EVP_MAC_CTX *ctx, mac_params *params) {
     }
     _params[n_params] = OSSL_PARAM_construct_end();
     if (0 == EVP_MAC_CTX_set_params(ctx, _params)) {
-        ERR_print_errors_fp(stdout);
+        ERR_print_errors_fp(stderr);
     }
 }
 
@@ -55,7 +55,7 @@ mac_context *mac_init(char *algorithm, byte *key, size_t key_length, mac_params 
     EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
     EVP_MAC_free(mac);
     if (NULL == ctx) { 
-        ERR_print_errors_fp(stdout);        
+        ERR_print_errors_fp(stderr);
         free_mac_context(new_ctx);
         return NULL;
     }
@@ -64,7 +64,7 @@ mac_context *mac_init(char *algorithm, byte *key, size_t key_length, mac_params 
         set_params(new_ctx->ctx, params);
     }
     if (0 == EVP_MAC_init(new_ctx->ctx, (const unsigned char*)key, key_length, NULL)) {
-        ERR_print_errors_fp(stdout);
+        ERR_print_errors_fp(stderr);
         free_mac_context(new_ctx);
         return NULL;
     }   

--- a/src/main/native/c/signature.c
+++ b/src/main/native/c/signature.c
@@ -22,6 +22,10 @@
 sv_key *sv_init_key(OSSL_LIB_CTX *libctx, EVP_PKEY *pkey) {
     sv_key *key = (sv_key*)malloc(sizeof(sv_key));
     key->ctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, NULL);
+    if (key->ctx == NULL) {
+        ERR_print_errors_fp(stderr);
+        return NULL;
+    }
     return key;
 }
   

--- a/src/test/conf/openssl.cnf
+++ b/src/test/conf/openssl.cnf
@@ -56,7 +56,6 @@ alg_section = algorithm_sect
 
 # List of providers to load
 [provider_sect]
-default = default_sect
 # The fips section name should match the section name inside the
 # included fipsmodule.cnf.
 fips = fips_sect
@@ -67,17 +66,6 @@ activate = 1
 
 [algorithm_sect]
 default_properties = fips=yes
-
-# If no providers are activated explicitly, the default one is activated implicitly.
-# See man 7 OSSL_PROVIDER-default for more details.
-#
-# If you add a section explicitly activating any other provider(s), you most
-# probably need to explicitly activate the default provider, otherwise it
-# becomes unavailable in openssl.  As a consequence applications depending on
-# OpenSSL may not work correctly which could lead to significant system
-# problems including inability to remotely access the system.
-[default_sect]
-# activate = 1
 
 
 ####################################################################

--- a/src/test/java/MacTest.java
+++ b/src/test/java/MacTest.java
@@ -112,7 +112,7 @@ public class MacTest {
     @Test
     public void testKMAC_128() throws Exception {
         runTest("KMAC-128",
-            new SecretKeySpec(Arrays.copyOfRange(key, 0, 4), "KMAC-128"),
+            new SecretKeySpec(Arrays.copyOfRange(key, 0, 16), "KMAC-128"),
             "KMAC128");
     }
 

--- a/src/test/java/ProviderSanityTest.java
+++ b/src/test/java/ProviderSanityTest.java
@@ -109,8 +109,8 @@ public class ProviderSanityTest {
     @Test
     public void testSignatures() {
         test(Signature.class, "RSA", SignatureRSA.class, "sigSpi");
-        test(Signature.class, "ED448", SignatureED448.class, "sigSpi");
-        test(Signature.class, "ED25519", SignatureED25519.class, "sigSpi");
+        //test(Signature.class, "ED448", SignatureED448.class, "sigSpi");
+        //test(Signature.class, "ED25519", SignatureED25519.class, "sigSpi");
     }
 
     @Test

--- a/src/test/java/SignatureTest.java
+++ b/src/test/java/SignatureTest.java
@@ -60,14 +60,12 @@ public class SignatureTest {
         testSignature("RSA", gen.pubKey, gen.privKey);
     }
 
-    @Test
     public void testED25519() throws Exception {
         EdDSAPublicKey publicKey = new EdDSAPublicKey("src/test/keys/ed25519-pub.pem");
         EdDSAPrivateKey privateKey = new EdDSAPrivateKey("src/test/keys/ed25519-priv.pem");
         testSignature("ED25519", publicKey, privateKey);
     }
 
-    @Test
     public void testED448() throws Exception {
         EdDSAPublicKey publicKey = new EdDSAPublicKey("src/test/keys/ed448-pub.pem");
         EdDSAPrivateKey privateKey = new EdDSAPrivateKey("src/test/keys/ed448-priv.pem");

--- a/src/test/native/mac.c
+++ b/src/test/native/mac.c
@@ -57,7 +57,7 @@ static unsigned char data[] =
 
 void run_test(mac_context *ctx) {
     if (NULL == ctx) {
-        printf("FAILED (Couldn't init CMAC)\n");
+        printf("FAILED (Couldn't init MAC)\n");
     }
 
     if(0 == (mac_update(ctx, data, sizeof(data)))) {
@@ -117,7 +117,7 @@ void test_gmac(OSSL_LIB_CTX *libctx) {
 
 void test_kmac128(OSSL_LIB_CTX *libctx) {
     printf("Testing KMAC-128: ");
-    mac_context *ctx = mac_init("KMAC-128", key, 4, NULL);
+    mac_context *ctx = mac_init("KMAC-128", key, 16, NULL);
     run_test(ctx);
     free_mac_context(ctx);
 }

--- a/src/test/native/signature.c
+++ b/src/test/native/signature.c
@@ -152,7 +152,7 @@ void test_ed448_sign_and_verify(OSSL_LIB_CTX *libctx) {
 int main(int argc, char ** argv) {
     OSSL_LIB_CTX *libctx = load_openssl_fips_provider("/usr/local/ssl/openssl.cnf"); 
     test_rsa_sign_and_verify(libctx);
-    test_ed25519_sign_and_verify(libctx);
-    test_ed448_sign_and_verify(libctx);
+    //test_ed25519_sign_and_verify(libctx);
+    //test_ed448_sign_and_verify(libctx);
     return rc;
 }


### PR DESCRIPTION
Building and testing the provider on Ubuntu Pro 22.04 with OpenJDK 21 led to some failures. This pull request contains the fixes. Here is a summary of the changes:

1. Loading openssl on Ubuntu Pro with `fips-updates` enabled loads the FIPS module by default. https://github.com/canonical/openssl-fips-java/commit/1107caa3ca3cc37aa007d78f30834882f486313f handles this scenario.
2. There is a lack of clarity on the FIPS approval of Ed25519 and Ed448 digital signatures. Though DSS 186-5 permits these digital signing algorithms, the FIPS module of openssl on Ubuntu 22.04 does not permit the creation of Ed25519 and Ed448 keys. However, I can see upstream openssl permitting the same. I have disabled these algorithms from the provider until we get some clarity here. The tests have also been disabled. https://github.com/canonical/openssl-fips-java/commit/318fb4380e7671b322ca09d4338cb41b151fb08b does this.
3. Native KMAC-128 tests used a key-size of 4 which is wrong. I am not sure why this failed only with Ubuntu Pro and not with a vanilla Ubuntu 22.04 install. But nevertheless, it is fixed now by https://github.com/canonical/openssl-fips-java/commit/48e55194883b437d580b23d26c6d54ced4c9b929.
4. The GitHub action is updated to use upstream openssl 3.0.2 which is the level shipped by Ubuntu Pro 22.04. We are also now doing an explicit install of the FIPS module, to make sure the default module does not get loaded.