### PR TITLE
Fix a possible cause of crashes in free()

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,4 +47,6 @@ jobs:
       if: always()
       with:
         name: maven-surefire-reports
-        path: ${{ github.workspace }}/target/surefire-reports
+        path: |
+          ${{ github.workspace }}/target/surefire-reports
+          ${{ github.workspace }}/build/test/test.out

--- a/pom.xml
+++ b/pom.xml
@@ -172,9 +172,6 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
-                    <excludes>
-                       <exclude>**/*SecureRandomTest.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>           
         </plugins>

--- a/src/main/native/c/signature.c
+++ b/src/main/native/c/signature.c
@@ -16,6 +16,7 @@
  */
 #include "signature.h"
 #include "jssl.h"
+#include <openssl/err.h>
 #include <openssl/rsa.h>
 #include <openssl/core_names.h>
 

--- a/src/test/java/SecureRandomTest.java
+++ b/src/test/java/SecureRandomTest.java
@@ -169,8 +169,8 @@ public class SecureRandomTest {
         testArrayInequality(hash1, hash2);
     }
 
-    /* disabled - needs a "double-free" investigation" */
-    private void testDRBGCreationWithParamsNextBytesWithParams() throws NoSuchAlgorithmException, NoSuchProviderException {
+    @Test
+    public void testDRBGCreationWithParamsNextBytesWithParams() throws NoSuchAlgorithmException, NoSuchProviderException {
         SecureRandomParameters params = DrbgParameters.instantiation(128, Capability.PR_AND_RESEED, "FIPSPROTOTYPE".getBytes());
         SecureRandomParameters nbParams = DrbgParameters.nextBytes(128, true, "ADDITIONALINPUT".getBytes());
 

--- a/src/test/runner.py
+++ b/src/test/runner.py
@@ -34,7 +34,7 @@ tests = {
 }
 
 def run_native_test(name):
-  return os.system(f"build/test/bin/{name} > /dev/null 2>&1")
+  return os.system(f"build/test/bin/{name} >> build/test/test.out 2>&1") 
 
 for test in tests.keys():
   name = tests[test]


### PR DESCRIPTION
While requesting for the next array of random bytes we were cleary malloc'ing memory of the wrong size (sizeof(length) instead of length).

This commit includes the bug fix and re-enables SecureRandomTest.