### PR TITLE
Don't use Files.createTempFile() while loading libjssl.so

### DIFF
--- a/src/main/java/com/canonical/openssl/util/NativeLibraryLoader.java
+++ b/src/main/java/com/canonical/openssl/util/NativeLibraryLoader.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class NativeLibraryLoader {
     static String libFileName = "libjssl.so";
@@ -34,7 +35,7 @@ public class NativeLibraryLoader {
         try {
             InputStream in = NativeLibraryLoader.class.getResourceAsStream(location + libFileName);
 
-            File tempFile = Files.createTempFile(libFileName, "").toFile();
+            File tempFile = Files.createFile(Paths.get("/tmp/" + libFileName)).toFile();
             tempFile.deleteOnExit();
 
             try (FileOutputStream out = new FileOutputStream(tempFile)) {
@@ -44,6 +45,7 @@ public class NativeLibraryLoader {
                     out.write(buffer, 0, bytesRead);
                 }
             }
+
             System.load(tempFile.getAbsolutePath());
             loaded = true;
         } catch (Exception e) {


### PR DESCRIPTION
During initialization of OpenSSLFIPSProvider, we load libjssl.so shipped as a resource from the jar file built by maven. We create a temporary file, copy the resource into it and call System.loadLibrary() on the temporary file.

The Files.createTempFile() method needs a SecureRandom. If OpenSSLFIPSProvider is configured as the provider with top priority, this will attempt to initialize OpenSSLDRBG causing a recursive attempt to load libjssl.so and failing with an NPE.

This commit removes the use of Files.createTempFile() to make sure no other security function is not invoked while loading libjssl.so during initialization.